### PR TITLE
新增用戶中心頁面及相關組件，包含社團和企業資料表單，並更新導航欄以包含個人資料選項

### DIFF
--- a/next/src/app/Profile/page.tsx
+++ b/next/src/app/Profile/page.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import ArticleIcon from "@mui/icons-material/Article";
+import EventIcon from "@mui/icons-material/Event";
+import HandshakeIcon from "@mui/icons-material/Handshake";
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Container,
+  Divider,
+  Paper,
+  Snackbar,
+  Typography,
+} from "@mui/material";
+import React, { useEffect, useRef, useState } from "react";
+import Navbar from "../../components/Navbar";
+import ClubProfileForm from "../../components/profile/ClubProfileForm";
+import CompanyProfileForm from "../../components/profile/CompanyProfileForm";
+import SideNavbar from "../../components/SideNavbar";
+import { authServices } from "../../firebase/services/auth-service";
+import { Club, clubServices } from "../../firebase/services/club-service";
+import {
+  Company,
+  companyServices,
+} from "../../firebase/services/company-service";
+
+// Tab panel component for content display
+function TabPanel(props: {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`profile-tabpanel-${index}`}
+      aria-labelledby={`profile-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ py: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+export default function Profile() {
+  const [value, setValue] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [clubData, setClubData] = useState<Club | null>(null);
+  const [companyData, setCompanyData] = useState<Company | null>(null);
+  const [userType, setUserType] = useState<"club" | "company" | "unknown">(
+    "unknown"
+  );
+  const [selectedTag, setSelectedTag] = useState<string | null>("個人檔案");
+  const [searchTerm, setSearchTerm] = useState("0"); // 將 searchTerm 用作頁籤索引
+  const drawerWidth = 200; // 側邊欄寬度設定為200px
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const currentUser = authServices.getCurrentUser();
+        if (!currentUser) {
+          setError("請先登入系統");
+          setLoading(false);
+          return;
+        }
+
+        // Try to fetch club data
+        const allClubs = await clubServices.getAllClubs();
+        const userClub = allClubs.find(
+          (club) => club.userId === currentUser.uid
+        );
+
+        if (userClub) {
+          setClubData(userClub);
+          setUserType("club");
+          setLoading(false);
+          return;
+        }
+
+        // If no club data, try to fetch company data
+        const allCompanies = await companyServices.getAllCompanies();
+        const userCompany = allCompanies.find(
+          (company) => company.email === currentUser.email
+        );
+
+        if (userCompany) {
+          setCompanyData(userCompany);
+          setUserType("company");
+          setLoading(false);
+          return;
+        }
+
+        setError("找不到您的用戶資料，請確認您已完成註冊流程");
+        setLoading(false);
+      } catch (err) {
+        console.error("Error fetching profile:", err);
+        setError("載入用戶資料時發生錯誤，請稍後再試");
+        setLoading(false);
+      }
+    };
+
+    fetchUserProfile();
+  }, []);
+
+  // 監聽 searchTerm 變化，更新選項卡索引
+  useEffect(() => {
+    if (searchTerm) {
+      setValue(parseInt(searchTerm));
+    }
+  }, [searchTerm]);
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const handleClubProfileUpdate = async (
+    updatedData: Partial<Club>,
+    logoFile?: File
+  ) => {
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (!clubData?.id) {
+        throw new Error("無法找到社團資料");
+      }
+
+      let logoURL = clubData.logoURL;
+
+      // Upload new logo if provided
+      if (logoFile) {
+        logoURL = await clubServices.uploadClubLogo(clubData.id, logoFile);
+      }
+
+      // Update club information
+      await clubServices.updateClub(clubData.id, {
+        ...updatedData,
+        logoURL,
+      });
+
+      // Refresh club data
+      const updatedClub = await clubServices.getClubById(clubData.id);
+      if (updatedClub) {
+        setClubData(updatedClub);
+      }
+
+      setSuccess("社團資料已成功更新");
+      setSnackbarOpen(true);
+      // Scroll to top of the content
+      if (contentRef.current) {
+        contentRef.current.scrollIntoView({ behavior: "smooth" });
+      }
+    } catch (err) {
+      console.error("Error updating club profile:", err);
+      setError("更新社團資料時發生錯誤，請稍後再試");
+      setSnackbarOpen(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCompanyProfileUpdate = async (
+    updatedData: Partial<Company>,
+    logoFile?: File
+  ) => {
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (!companyData?.id) {
+        throw new Error("無法找到企業資料");
+      }
+
+      let logoURL = companyData.logoURL;
+
+      // Upload new logo if provided
+      if (logoFile) {
+        logoURL = await companyServices.uploadCompanyLogo(
+          companyData.id,
+          logoFile
+        );
+      }
+
+      // Update company information
+      await companyServices.updateCompany(companyData.id, {
+        ...updatedData,
+        logoURL,
+      });
+
+      // Refresh company data
+      const updatedCompany = await companyServices.getCompanyById(
+        companyData.id
+      );
+      if (updatedCompany) {
+        setCompanyData(updatedCompany);
+      }
+
+      setSuccess("企業資料已成功更新");
+      setSnackbarOpen(true);
+      // Scroll to top of the content
+      if (contentRef.current) {
+        contentRef.current.scrollIntoView({ behavior: "smooth" });
+      }
+    } catch (err) {
+      console.error("Error updating company profile:", err);
+      setError("更新企業資料時發生錯誤，請稍後再試");
+      setSnackbarOpen(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <>
+        <Navbar />
+        <Box
+          sx={{
+            pt: "64px", // 為頂部導航條留出空間
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: "calc(100vh - 64px)",
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* 頂部導航列 */}
+      <Navbar />
+
+      {/* 主要布局 */}
+      <Box
+        sx={{
+          display: "flex",
+          pt: "64px", // 為頂部導航條留出空間
+          minHeight: "calc(100vh - 64px)",
+          backgroundColor: (theme) => theme.palette.grey[50], // 淺灰色背景增加層次感
+        }}
+      >
+        {/* 側邊導航 */}
+        <SideNavbar
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          selectedTag={selectedTag}
+          setSelectedTag={setSelectedTag}
+          drawerWidth={drawerWidth}
+        />
+
+        {/* 主要內容區域 */}
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: { xs: 2, sm: 4 }, // 響應式內邊距
+            width: { md: `calc(100% - ${drawerWidth}px)` },
+            ml: { md: `${drawerWidth}px` },
+          }}
+        >
+          <Container maxWidth="md" sx={{ pb: 5 }}>
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 2, sm: 3, md: 4 },
+                mb: 4,
+                borderRadius: 2,
+                border: "1px solid rgba(0, 0, 0, 0.05)",
+                boxShadow: "0 4px 20px rgba(0, 0, 0, 0.05)",
+              }}
+            >
+              <Box ref={contentRef}>
+                <Typography
+                  variant="h4"
+                  component="h1"
+                  gutterBottom
+                  sx={{
+                    fontWeight: 700,
+                    mb: 2,
+                    color: (theme) => theme.palette.primary.main,
+                  }}
+                >
+                  用戶中心
+                </Typography>
+
+                <Divider sx={{ my: 2 }} />
+              </Box>
+
+              {/* Replaced Alert with Snackbar for better UX */}
+              <Snackbar
+                open={snackbarOpen && (!!error || !!success)}
+                autoHideDuration={5000}
+                onClose={() => setSnackbarOpen(false)}
+                anchorOrigin={{ vertical: "top", horizontal: "center" }}
+              >
+                <Alert
+                  severity={error ? "error" : "success"}
+                  sx={{
+                    width: "100%",
+                    boxShadow: 3,
+                    "& .MuiAlert-icon": { alignItems: "center" },
+                  }}
+                  onClose={() => setSnackbarOpen(false)}
+                >
+                  {error || success}
+                </Alert>
+              </Snackbar>
+
+              {/* 內容區域 - 根據側邊欄選擇顯示不同內容 */}
+
+              <TabPanel value={value} index={0}>
+                {userType === "club" && clubData && (
+                  <ClubProfileForm
+                    clubData={clubData}
+                    onSubmit={handleClubProfileUpdate}
+                  />
+                )}
+
+                {userType === "company" && companyData && (
+                  <CompanyProfileForm
+                    companyData={companyData}
+                    onSubmit={handleCompanyProfileUpdate}
+                  />
+                )}
+
+                {userType === "unknown" && (
+                  <Typography>請先完成註冊流程以管理您的個人資料</Typography>
+                )}
+              </TabPanel>
+
+              <TabPanel value={value} index={1}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    py: 4,
+                  }}
+                >
+                  <ArticleIcon
+                    sx={{ fontSize: 80, color: "text.disabled", mb: 2 }}
+                  />
+                  <Typography variant="h6" color="text.secondary" gutterBottom>
+                    尚無已發佈文章
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    align="center"
+                  >
+                    您還沒有發佈任何文章。發佈功能正在開發中，敬請期待！
+                  </Typography>
+                </Box>
+              </TabPanel>
+
+              <TabPanel value={value} index={2}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    py: 4,
+                  }}
+                >
+                  <HandshakeIcon
+                    sx={{ fontSize: 80, color: "text.disabled", mb: 2 }}
+                  />
+                  <Typography variant="h6" color="text.secondary" gutterBottom>
+                    尚無合作紀錄
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    align="center"
+                  >
+                    您目前沒有任何合作紀錄。合作紀錄功能正在開發中，敬請期待！
+                  </Typography>
+                </Box>
+              </TabPanel>
+
+              <TabPanel value={value} index={3}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    py: 4,
+                  }}
+                >
+                  <EventIcon
+                    sx={{ fontSize: 80, color: "text.disabled", mb: 2 }}
+                  />
+                  <Typography variant="h6" color="text.secondary" gutterBottom>
+                    尚無活動資訊
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    align="center"
+                  >
+                    您目前沒有任何活動資訊。活動資訊功能正在開發中，敬請期待！
+                  </Typography>
+                </Box>
+              </TabPanel>
+            </Paper>
+          </Container>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/next/src/components/Navbar.tsx
+++ b/next/src/components/Navbar.tsx
@@ -32,6 +32,7 @@ const pages = [
   { name: "首頁", path: "/" },
   { name: "企業列表", path: "/CompanyList" },
   { name: "文章發布", path: "/Artical" },
+  { name: "個人資料", path: "/Profile" },
 ];
 
 const userOptions = [

--- a/next/src/components/SideNavbar.tsx
+++ b/next/src/components/SideNavbar.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import ArticleIcon from "@mui/icons-material/Article";
+import EventIcon from "@mui/icons-material/Event";
+import FolderIcon from "@mui/icons-material/Folder";
+import HandshakeIcon from "@mui/icons-material/Handshake";
+import PersonIcon from "@mui/icons-material/Person";
+import {
+  Box,
+  Chip,
+  Drawer,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import { useState } from "react";
+
+interface SideNavbarProps {
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  selectedTag: string | null;
+  setSelectedTag: (tag: string | null) => void;
+  drawerWidth?: number;
+}
+
+export default function SideNavbar({
+  searchTerm,
+  setSearchTerm,
+  selectedTag,
+  setSelectedTag,
+  drawerWidth = 240,
+}: SideNavbarProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // 直接在組件內部定義標籤列表
+  const availableTags = ["個人檔案", "已發佈文章", "合作紀錄", "活動資訊"];
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  // 處理標籤點擊，設置選中的標籤
+  const handleTagClick = (tag: string) => {
+    setSelectedTag(tag);
+    // 根據標籤設置對應的索引值
+    const index = availableTags.indexOf(tag);
+    // 如果 setSearchTerm 是用來設置 tab index 的，也可以更新它
+    setSearchTerm(index.toString());
+  };
+
+  const drawerContent = (
+    <Box
+      sx={{
+        p: 3,
+        width: drawerWidth,
+        height: "100%",
+        backgroundColor: theme.palette.background.default,
+      }}
+    >
+      <Typography
+        variant="h6"
+        sx={{ mb: 3, fontWeight: "bold", color: theme.palette.primary.main }}
+      >
+        個人中心
+      </Typography>
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+        }}
+      >
+        {availableTags.map((tag) => {
+          // Determine the appropriate icon for each tag
+          let icon;
+          switch (tag) {
+            case "個人檔案":
+              icon = <PersonIcon fontSize="small" />;
+              break;
+            case "已發佈文章":
+              icon = <ArticleIcon fontSize="small" />;
+              break;
+            case "合作紀錄":
+              icon = <HandshakeIcon fontSize="small" />;
+              break;
+            case "活動資訊":
+              icon = <EventIcon fontSize="small" />;
+              break;
+            default:
+              icon = <FolderIcon fontSize="small" />;
+          }
+
+          return (
+            <Chip
+              key={tag}
+              label={tag}
+              icon={icon}
+              color={selectedTag === tag ? "primary" : "default"}
+              onClick={() => handleTagClick(tag)}
+              clickable
+              sx={{
+                mb: 0.5,
+                py: 0.5,
+                borderRadius: "4px",
+                fontWeight: selectedTag === tag ? "bold" : "normal",
+                boxShadow: selectedTag === tag ? 1 : 0,
+                position: "relative",
+                pl: selectedTag === tag ? 0.5 : 1,
+                "&:before":
+                  selectedTag === tag
+                    ? {
+                        content: '""',
+                        position: "absolute",
+                        left: 0,
+                        top: "50%",
+                        transform: "translateY(-50%)",
+                        width: "4px",
+                        height: "70%",
+                        backgroundColor: theme.palette.primary.main,
+                        borderRadius: "2px",
+                      }
+                    : {},
+                "&:hover": {
+                  backgroundColor:
+                    selectedTag === tag
+                      ? theme.palette.primary.light
+                      : theme.palette.action.hover,
+                },
+              }}
+            />
+          );
+        })}
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Box
+      component="nav"
+      sx={{ width: { md: drawerWidth }, flexShrink: { md: 0 } }}
+    >
+      {/* Permanent drawer for desktop */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: "none", md: "block" },
+          "& .MuiDrawer-paper": {
+            boxSizing: "border-box",
+            width: drawerWidth,
+            borderRight: "1px solid rgba(0, 0, 0, 0.08)",
+            top: "64px", // 確保抽屜從頂部導航欄下方開始
+            height: "calc(100% - 64px)",
+            overflowY: "visible", // 移除滾動條
+            overflowX: "visible",
+            backgroundColor: theme.palette.background.default,
+            zIndex: (theme) => theme.zIndex.drawer, // 設定合適的 z-index
+          },
+        }}
+        open
+      >
+        {drawerContent}
+      </Drawer>
+    </Box>
+  );
+}

--- a/next/src/components/profile/ClubProfileForm.tsx
+++ b/next/src/components/profile/ClubProfileForm.tsx
@@ -1,0 +1,268 @@
+import SaveIcon from "@mui/icons-material/Save";
+import UploadIcon from "@mui/icons-material/Upload";
+import {
+  Avatar,
+  Button,
+  FormHelperText,
+  Grid,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import React, { useState } from "react";
+import { Club } from "../../firebase/services/club-service";
+
+interface ClubProfileFormProps {
+  clubData: Club;
+  onSubmit: (updatedData: Partial<Club>, logoFile?: File) => Promise<void>;
+}
+
+const ClubProfileForm: React.FC<ClubProfileFormProps> = ({
+  clubData,
+  onSubmit,
+}) => {
+  const [formData, setFormData] = useState<Partial<Club>>({
+    clubName: clubData.clubName || "",
+    schoolName: clubData.schoolName || "",
+    contactName: clubData.contactName || "",
+    contactPhone: clubData.contactPhone || "",
+    email: clubData.email || "",
+    clubDescription: clubData.clubDescription || "",
+  });
+
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [logoPreview, setLogoPreview] = useState<string | null>(
+    clubData.logoURL || null
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<keyof Club, string>>>({});
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    // Clear error when user types
+    if (errors[name as keyof Club]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: "",
+      }));
+    }
+  };
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+      setLogoFile(file);
+      setLogoPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Partial<Record<keyof Club, string>> = {};
+
+    if (!formData.clubName?.trim()) {
+      newErrors.clubName = "請輸入社團名稱";
+    }
+
+    if (!formData.contactName?.trim()) {
+      newErrors.contactName = "請輸入聯絡人姓名";
+    }
+
+    if (!formData.contactPhone?.trim()) {
+      newErrors.contactPhone = "請輸入聯絡電話";
+    } else if (!/^[0-9]{8,10}$/.test(formData.contactPhone.trim())) {
+      newErrors.contactPhone = "請輸入有效的電話號碼";
+    }
+
+    if (!formData.email?.trim()) {
+      newErrors.email = "請輸入電子郵件";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email.trim())) {
+      newErrors.email = "請輸入有效的電子郵件地址";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(formData, logoFile || undefined);
+      if (logoFile) {
+        setLogoFile(null);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+      <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 3 }}>
+        社團資料
+      </Typography>
+
+      <form onSubmit={handleSubmit}>
+        <Grid container spacing={3}>
+          {/* Logo Upload Section */}
+          <Grid
+            item
+            xs={12}
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            sx={{ mb: 2 }}
+          >
+            <Typography variant="subtitle1" gutterBottom>
+              社團標誌
+            </Typography>
+
+            <Avatar
+              src={logoPreview || undefined}
+              alt={formData.clubName || "社團標誌"}
+              sx={{ width: 120, height: 120, mb: 2 }}
+            />
+
+            <Button
+              component="label"
+              variant="outlined"
+              startIcon={<UploadIcon />}
+              size="small"
+            >
+              上傳標誌
+              <input
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={handleLogoChange}
+              />
+            </Button>
+            <FormHelperText>
+              建議尺寸: 400x400像素，檔案大小不超過2MB
+            </FormHelperText>
+          </Grid>
+
+          {/* Club Information Fields */}
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="社團名稱"
+              name="clubName"
+              value={formData.clubName}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.clubName}
+              helperText={errors.clubName}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="學校名稱"
+              name="schoolName"
+              value={formData.schoolName}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.schoolName}
+              helperText={errors.schoolName}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="聯絡人姓名"
+              name="contactName"
+              value={formData.contactName}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.contactName}
+              helperText={errors.contactName}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="聯絡電話"
+              name="contactPhone"
+              value={formData.contactPhone}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.contactPhone}
+              helperText={errors.contactPhone}
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="電子郵件"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.email}
+              helperText={errors.email}
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="社團簡介"
+              name="clubDescription"
+              value={formData.clubDescription}
+              onChange={handleChange}
+              margin="normal"
+              multiline
+              rows={4}
+              placeholder="請輸入社團簡介，描述社團的宗旨、活動內容等"
+              helperText="建議字數：100-300字"
+            />
+          </Grid>
+
+          {/* Submit Button */}
+          <Grid
+            item
+            xs={12}
+            display="flex"
+            justifyContent="center"
+            sx={{ mt: 2 }}
+          >
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              size="large"
+              disabled={isSubmitting}
+              startIcon={<SaveIcon />}
+              sx={{ minWidth: 120 }}
+            >
+              {isSubmitting ? "儲存中..." : "儲存變更"}
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </Paper>
+  );
+};
+
+export default ClubProfileForm;

--- a/next/src/components/profile/CompanyProfileForm.tsx
+++ b/next/src/components/profile/CompanyProfileForm.tsx
@@ -1,0 +1,319 @@
+import SaveIcon from "@mui/icons-material/Save";
+import UploadIcon from "@mui/icons-material/Upload";
+import {
+  Avatar,
+  Button,
+  FormHelperText,
+  Grid,
+  MenuItem,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import React, { useState } from "react";
+import { Company } from "../../firebase/services/company-service";
+
+interface CompanyProfileFormProps {
+  companyData: Company;
+  onSubmit: (updatedData: Partial<Company>, logoFile?: File) => Promise<void>;
+}
+
+// Industry types options
+const industryTypes = [
+  "科技/IT",
+  "金融/保險",
+  "零售/電商",
+  "製造/工業",
+  "教育/培訓",
+  "醫療/健康",
+  "餐飲/娛樂",
+  "媒體/廣告",
+  "非營利組織",
+  "其他",
+];
+
+const CompanyProfileForm: React.FC<CompanyProfileFormProps> = ({
+  companyData,
+  onSubmit,
+}) => {
+  const [formData, setFormData] = useState<Partial<Company>>({
+    companyName: companyData.companyName || "",
+    businessId: companyData.businessId || "",
+    industryType: companyData.industryType || "",
+    contactName: companyData.contactName || "",
+    contactPhone: companyData.contactPhone || "",
+    email: companyData.email || "",
+    companyDescription: companyData.companyDescription || "",
+  });
+
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [logoPreview, setLogoPreview] = useState<string | null>(
+    companyData.logoURL || null
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<keyof Company, string>>>(
+    {}
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    // Clear error when user types
+    if (errors[name as keyof Company]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: "",
+      }));
+    }
+  };
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+      setLogoFile(file);
+      setLogoPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Partial<Record<keyof Company, string>> = {};
+
+    if (!formData.companyName?.trim()) {
+      newErrors.companyName = "請輸入企業名稱";
+    }
+
+    if (!formData.contactName?.trim()) {
+      newErrors.contactName = "請輸入聯絡人姓名";
+    }
+
+    if (!formData.contactPhone?.trim()) {
+      newErrors.contactPhone = "請輸入聯絡電話";
+    } else if (!/^[0-9]{8,10}$/.test(formData.contactPhone.trim())) {
+      newErrors.contactPhone = "請輸入有效的電話號碼";
+    }
+
+    if (!formData.email?.trim()) {
+      newErrors.email = "請輸入電子郵件";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email.trim())) {
+      newErrors.email = "請輸入有效的電子郵件地址";
+    }
+
+    if (!formData.industryType) {
+      newErrors.industryType = "請選擇產業類型";
+    }
+
+    if (!formData.businessId?.trim()) {
+      newErrors.businessId = "請輸入統一編號";
+    } else if (!/^[0-9]{8}$/.test(formData.businessId.trim())) {
+      newErrors.businessId = "統一編號必須為8位數字";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(formData, logoFile || undefined);
+      if (logoFile) {
+        setLogoFile(null);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+      <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 3 }}>
+        企業資料
+      </Typography>
+
+      <form onSubmit={handleSubmit}>
+        <Grid container spacing={3}>
+          {/* Logo Upload Section */}
+          <Grid
+            item
+            xs={12}
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            sx={{ mb: 2 }}
+          >
+            <Typography variant="subtitle1" gutterBottom>
+              企業標誌
+            </Typography>
+
+            <Avatar
+              src={logoPreview || undefined}
+              alt={formData.companyName || "企業標誌"}
+              sx={{ width: 120, height: 120, mb: 2 }}
+            />
+
+            <Button
+              component="label"
+              variant="outlined"
+              startIcon={<UploadIcon />}
+              size="small"
+            >
+              上傳標誌
+              <input
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={handleLogoChange}
+              />
+            </Button>
+            <FormHelperText>
+              建議尺寸: 400x400像素，檔案大小不超過2MB
+            </FormHelperText>
+          </Grid>
+
+          {/* Company Information Fields */}
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="企業名稱"
+              name="companyName"
+              value={formData.companyName}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.companyName}
+              helperText={errors.companyName}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="統一編號"
+              name="businessId"
+              value={formData.businessId}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.businessId}
+              helperText={errors.businessId}
+              disabled={!!companyData.businessId} // 已註冊的企業不可更改統一編號
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              select
+              fullWidth
+              label="產業類型"
+              name="industryType"
+              value={formData.industryType}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.industryType}
+              helperText={errors.industryType || "請選擇最接近貴公司的產業類型"}
+            >
+              {industryTypes.map((option) => (
+                <MenuItem key={option} value={option}>
+                  {option}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="聯絡人姓名"
+              name="contactName"
+              value={formData.contactName}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.contactName}
+              helperText={errors.contactName}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="聯絡電話"
+              name="contactPhone"
+              value={formData.contactPhone}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.contactPhone}
+              helperText={errors.contactPhone}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="電子郵件"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              margin="normal"
+              required
+              error={!!errors.email}
+              helperText={errors.email}
+              disabled={!!companyData.email} // 已註冊的企業不可更改郵件
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="企業簡介"
+              name="companyDescription"
+              value={formData.companyDescription}
+              onChange={handleChange}
+              margin="normal"
+              multiline
+              rows={4}
+              placeholder="請輸入企業簡介，描述企業文化、產品服務等"
+              helperText="建議字數：100-300字"
+            />
+          </Grid>
+
+          {/* Submit Button */}
+          <Grid
+            item
+            xs={12}
+            display="flex"
+            justifyContent="center"
+            sx={{ mt: 2 }}
+          >
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              size="large"
+              disabled={isSubmitting}
+              startIcon={<SaveIcon />}
+              sx={{ minWidth: 120 }}
+            >
+              {isSubmitting ? "儲存中..." : "儲存變更"}
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </Paper>
+  );
+};
+
+export default CompanyProfileForm;


### PR DESCRIPTION
待解決問題
1. Sidebar 和上方 Navbar 重疊
2. 網頁重新刷新後會遺失已登入使用者資料
3. 需確認企業上傳頭貼後的儲存位置
4. 登出後 個人資料介面維持原樣（應該跳轉回首頁，或是換成沒有登入的頁面）